### PR TITLE
return rewriting workaround

### DIFF
--- a/results.nim
+++ b/results.nim
@@ -1161,13 +1161,21 @@ template `?`*[T, E](self: Result[T, E]): auto =
   let v = (self)
   case v.oResultPrivate
   of false:
+    # Instead of `return xxx` we use `result = xxx; return` which avoids the
+    # need to rewrite `return` in macros that take over the `result` symbol and
+    # its associated control flow - this hack increases compatibility with
+    # chronos' async - see https://github.com/status-im/nim-stew/issues/37 for
+    # more in-depth discussion.
     when typeof(result) is typeof(v):
-      return v
+      result = v
+      return
     else:
       when E is void:
-        return err(typeof(result))
+        result = err(typeof(result))
+        return
       else:
-        return err(typeof(result), v.eResultPrivate)
+        result = err(typeof(result), v.eResultPrivate)
+        return
   of true:
     when not(T is void):
       v.vResultPrivate


### PR DESCRIPTION
as an alternative to https://github.com/status-im/nim-stew/pull/134/, this PR provides an accidental workaround to the underlying issue, which is that macros are generally unable to rewrite `template` contents since the macro rewriting happens before template expansion.

splitting up `result` assignment and `return` allows binding to the injected `result` and `return` without argument ends up being "implicitly" compatible with the way `async` code is turned into a closure iterator.