### PR TITLE
test refc in CI in Nim 2.0 and later

### DIFF
--- a/results.nimble
+++ b/results.nimble
@@ -21,7 +21,7 @@ proc test(env, path: string) =
 task test, "Runs the test suite":
   for f in ["test_results.nim", "test_results2.nim"]:
     test "", "tests/" & f
-    if (NimMajor, NimMinor) > (1, 6):
+    if (NimMajor, NimMinor) >= (2, 0):
       test "--mm:refc", "tests/" & f
 
 task bench, "Run benchmark":

--- a/results.nimble
+++ b/results.nimble
@@ -8,7 +8,7 @@ skipDirs      = @["benchmarks", "tests"]
 installFiles  = @["results.nim"]
 # Dependencies
 
-requires "nim >= 1.6"
+requires "nim >= 1.2"
 
 proc test(env, path: string) =
   # Compilation language is controlled by TEST_LANG

--- a/results.nimble
+++ b/results.nimble
@@ -8,7 +8,7 @@ skipDirs      = @["benchmarks", "tests"]
 installFiles  = @["results.nim"]
 # Dependencies
 
-requires "nim >= 1.2"
+requires "nim >= 1.6"
 
 proc test(env, path: string) =
   # Compilation language is controlled by TEST_LANG
@@ -21,6 +21,8 @@ proc test(env, path: string) =
 task test, "Runs the test suite":
   for f in ["test_results.nim", "test_results2.nim"]:
     test "", "tests/" & f
+    if (NimMajor, NimMinor) > (1, 6):
+      test "--mm:refc", "tests/" & f
 
 task bench, "Run benchmark":
   test "-d:release", "benchmarks/benchmark.nim"


### PR DESCRIPTION
Regarding Nim 1.2, it hasn't worked for months:
![2024-02-18T14:31:12,321196896+01:00](https://github.com/arnetheduck/nim-results/assets/11422416/5ed3a51a-9307-4acd-b987-673ad05317ce)
![2024-02-18T14:32:11,772967249+01:00](https://github.com/arnetheduck/nim-results/assets/11422416/20f4c8df-335f-446b-b8b3-8e310240b00e)