### PR TITLE
change `tryGet()` API misuse to `Defect`

### DIFF
--- a/results.nim
+++ b/results.nim
@@ -357,7 +357,7 @@ func raiseResultError[T, E](self: Result[T, E]) {.noreturn, noinline.} =
 
   when E is ref Exception:
     if self.eResultPrivate.isNil: # for example Result.default()!
-      raise (ref ResultError[void])(msg: "Trying to access value with err (nil)")
+      raise (ref ResultDefect)(msg: "Trying to access value with err (nil)")
     raise self.eResultPrivate
   elif E is void:
     raise (ref ResultError[void])(msg: "Trying to access value with err")


### PR DESCRIPTION
Assuming a `Result[T, E]` with `E: Exception`, `tryGet` has the nasty side effect of triggering `{.raises: [E, ResultError[void]].}`. This is because it tries to play nice when `tryGet()` is called on a `Result` that has not yet been initialized.

That is not in line with how Nim typically operates. Accessing items that are not initialized may yield to SIGSEGV in many situations.

```nim
proc f() =
  var x: ref CatchableError
  raise x

f()
```

`tryGet()` semantics are well-defined for an initialized `Result`.
- If a value has been set, it is returned.
- If an error has been set, it is raised.

Calling `tryGet()` on un-initialized data is not a typical usecase and could instead become a `ResultDefect`. This way, it is not required anymore to `except + discard` the `ResultError[void]` for hypothetical API misuse, or to alternatively pollute the callstack with `{.raises.}`.

The alternatiev would be to `raise E(msg: ...)` instead, but that one may trigger unexpected behaviour as it hides the API misuse error.