### PR TITLE
extend `optValue` support for `Result[void, E]`

### DIFF
--- a/results.nim
+++ b/results.nim
@@ -935,7 +935,10 @@ func optValue*[T, E](self: Result[T, E]): Opt[T] =
   ## Return the value of a Result as an Opt, or none if Result is an error
   case self.oResultPrivate
   of true:
-    Opt.some(self.vResultPrivate)
+    when T is void:
+      Opt[void].ok()
+    else:
+      Opt.some(self.vResultPrivate)
   of false:
     Opt.none(T)
 


### PR DESCRIPTION
Fixes an error that shows when using `optValue` on a `Result[void, E]`.

```
undeclared field: 'vResultPrivate' for type results.Result
```